### PR TITLE
chore(dev.yml): update the version of the publish-storybook-workflow.…

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,7 +14,7 @@ jobs:
       with-docker-registry-login: false
 
   docs:
-    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@51876c9708ed846aae7bf32a77715a371609540e
     permissions:
       contents: read
       packages: write
@@ -22,6 +22,7 @@ jobs:
       id-token: write
     with:
       storybook-dir: ''
+      storybook-static-dir-separator: ''
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
…yml action to commit 51876c9708ed846aae7bf32a77715a371609540e

The change updates the version of the publish-storybook-workflow.yml action to a specific commit hash (51876c9708ed846aae7bf32a77715a371609540e) to ensure a specific version is used for consistency and reproducibility in the workflow.