### PR TITLE
ci(dev.yml): update commit hashes for workflow files to latest versions

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,7 +4,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   dev:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@e14c0ac441847f6d2938555a4bbab60214bc7179
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@76745d711c7743b1183be3ea9794123b7b1d6a04
     permissions:
       contents: read
       packages: write
@@ -15,7 +15,7 @@ jobs:
       with-docker-registry-login: false
 
   docs:
-    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@e14c0ac441847f6d2938555a4bbab60214bc7179
+    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@76745d711c7743b1183be3ea9794123b7b1d6a04
     permissions:
       contents: read
       packages: write

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ lint:
 	yarn eslintCheck
 
 build-pre:
+	@yarn install --frozen-lockfile --ignore-scripts
 	VERSION=$(VERSION) yarn publishWorkspaces:version
 
 build: build-libs
@@ -17,7 +18,7 @@ test:
 	echo 'No Test'
 
 publish:
-	TAG=$(VERSION) yarn publishWorkspaces:github
+	yarn publishWorkspaces:github
 
 promote:
 	VERSION=$(VERSION) yarn publishWorkspaces:npm


### PR DESCRIPTION
build(Makefile): add yarn install command with frozen-lockfile flag to ensure consistent dependencies installation The commit updates the commit hashes for the workflow files in the dev.yml file to the latest versions. This ensures that the workflows are using the most up-to-date configurations. Additionally, a yarn install command with the frozen-lockfile flag is added to the Makefile's build-pre target to ensure consistent dependencies installation.