### PR TITLE
chore(Makefile): remove VERSION variable from promote target to prevent unnecessary version bumping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ publish:
 	yarn publishWorkspaces:github
 
 promote:
-	VERSION=$(VERSION) yarn publishWorkspaces:github
+	yarn publishWorkspaces:github
 
 build-libs:
 	@yarn install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
The VERSION variable was removed from the promote target to prevent unintentional version bumping when running the yarn publishWorkspaces:github command. This change ensures that the promote target only triggers the publishing of workspaces without affecting the version.