### PR TITLE
chore(dev.yml): update workflow references to latest commit hashes fo…

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,7 +4,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   dev:
-    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@76745d711c7743b1183be3ea9794123b7b1d6a04
+    uses: komune-io/fixers-gradle/.github/workflows/make-nodejs-workflow.yml@98fc8e4e9685554dc87e15fbcde14b77b4413deb
     permissions:
       contents: read
       packages: write
@@ -15,7 +15,7 @@ jobs:
       with-docker-registry-login: false
 
   docs:
-    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@76745d711c7743b1183be3ea9794123b7b1d6a04
+    uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@98fc8e4e9685554dc87e15fbcde14b77b4413deb
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
…r make-nodejs-workflow.yml and publish-storybook-workflow.yml

The workflow references in dev.yml have been updated to use the latest commit hashes for make-nodejs-workflow.yml and publish-storybook-workflow.yml. This ensures that the workflows are using the most up-to-date configurations and settings.