### PR TITLE
chore(Makefile): refactor Makefile to improve build process and dependency management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,13 @@ clean:
 	-find ./packages/*/ -name "node_modules" -type d -exec rm -rf {} \;
 	-find ./packages/*/ -name "dist" -type d -exec rm -rf {} \;
 
-lint:
-	yarn eslintCheck
-
-build-pre:
+install:
 	@yarn install --frozen-lockfile --ignore-scripts
+
+lint: install
+	@yarn eslintCheck
+
+build-pre: install
 	VERSION=$(VERSION) yarn workspaces:version
 
 build: build-libs
@@ -24,7 +26,6 @@ promote:
 	yarn workspaces:publish
 
 build-libs:
-	@yarn install --frozen-lockfile --ignore-scripts
 	@yarn workspace @komune-io/g2-utils run build
 	@yarn workspace @komune-io/g2-themes run build
 	@yarn workspace @komune-io/g2-notifications run build

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ publish:
 promote:
 	yarn workspaces:publish
 
-build-libs:
+build-libs: install
 	@yarn workspace @komune-io/g2-utils run build
 	@yarn workspace @komune-io/g2-themes run build
 	@yarn workspace @komune-io/g2-notifications run build


### PR DESCRIPTION
The Makefile has been refactored to streamline the build process and improve dependency management. The `install` target has been added to ensure dependencies are installed before running linting and building tasks. This change enhances the reliability and consistency of the build process by ensuring that all necessary dependencies are in place before executing subsequent tasks.