### PR TITLE
feat(Gallery): add support for displaying multiple files in the Gallery component

### DIFF
--- a/packages/fs/src/Gallery/Components/Gallery/Gallery.stories.tsx
+++ b/packages/fs/src/Gallery/Components/Gallery/Gallery.stories.tsx
@@ -5,11 +5,147 @@ import { Box } from '@mui/material'
 import horizontalSrc from './horizontal.jpg'
 import verticalSrc from './vertical.jpg'
 import squaredSrc from './squared.jpg'
+import { FsFile } from '../../Domain'
 
 export default {
   title: 'Fs/Gallery',
   component: Gallery
 } as Meta
+
+const files: FsFile[] = [
+  {
+    id: '1',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'horizontal.jpg'
+    },
+    url: horizontalSrc
+  },
+  {
+    id: '2',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'squared.jpg'
+    },
+    url: squaredSrc
+  },
+  {
+    id: '3',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'vertical.jpg'
+    },
+    url: verticalSrc
+  },
+  {
+    id: '4',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'vertical.jpg'
+    },
+    url: verticalSrc
+  },
+  {
+    id: '5',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'horizontal.jpg'
+    },
+    url: horizontalSrc
+  },
+  {
+    id: '6',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'horizontal.jpg'
+    },
+    url: horizontalSrc
+  },
+  {
+    id: '7',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'squared.jpg'
+    },
+    url: squaredSrc
+  },
+  {
+    id: '8',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'vertical.jpg'
+    },
+    url: verticalSrc
+  },
+  {
+    id: '9',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'horizontal.jpg'
+    },
+    url: horizontalSrc
+  },
+  {
+    id: '10',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'squared.jpg'
+    },
+    url: squaredSrc
+  },
+  {
+    id: '11',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'vertical.jpg'
+    },
+    url: verticalSrc
+  },
+  {
+    id: '12',
+    metadata: {},
+    path: {
+      directory: 'files',
+      objectId: '1',
+      objectType: 'objectType',
+      name: 'horizontal.jpg'
+    },
+    url: horizontalSrc
+  }
+]
 
 export const GalleryStory: StoryFn<GalleryProps> = (args: GalleryProps) => {
   return (
@@ -25,116 +161,33 @@ export const GalleryStory: StoryFn<GalleryProps> = (args: GalleryProps) => {
 }
 
 GalleryStory.args = {
-  files: [
-    {
-      id: '1',
-      metadata: {},
-      path: {
-        name: 'horizontal.jpg'
-      },
-      objectId: '1',
-      url: horizontalSrc
-    },
-    {
-      id: '2',
-      metadata: {},
-      path: {
-        name: 'squared.jpg'
-      },
-      objectId: '2',
-      url: squaredSrc
-    },
-    {
-      id: '3',
-      metadata: {},
-      path: {
-        name: 'vertical.jpg'
-      },
-      objectId: '3',
-      url: verticalSrc
-    },
-    {
-      id: '4',
-      metadata: {},
-      path: {
-        name: 'vertical.jpg'
-      },
-      objectId: '4',
-      url: verticalSrc
-    },
-    {
-      id: '5',
-      metadata: {},
-      path: {
-        name: 'horizontal.jpg'
-      },
-      objectId: '5',
-      url: horizontalSrc
-    },
-    {
-      id: '6',
-      metadata: {},
-      path: {
-        name: 'horizontal.jpg'
-      },
-      objectId: '6',
-      url: horizontalSrc
-    },
-    {
-      id: '7',
-      metadata: {},
-      path: {
-        name: 'squared.jpg'
-      },
-      objectId: '7',
-      url: squaredSrc
-    },
-    {
-      id: '8',
-      metadata: {},
-      path: {
-        name: 'vertical.jpg'
-      },
-      objectId: '8',
-      url: verticalSrc
-    },
-    {
-      id: '9',
-      metadata: {},
-      path: {
-        name: 'horizontal.jpg'
-      },
-      objectId: '9',
-      url: horizontalSrc
-    },
-    {
-      id: '10',
-      metadata: {},
-      path: {
-        name: 'squared.jpg'
-      },
-      objectId: '9',
-      url: squaredSrc
-    },
-    {
-      id: '11',
-      metadata: {},
-      path: {
-        name: 'vertical.jpg'
-      },
-      objectId: '10',
-      url: verticalSrc
-    },
-    {
-      id: '12',
-      metadata: {},
-      path: {
-        name: 'horizontal.jpg'
-      },
-      objectId: '11',
-      url: horizontalSrc
-    }
-  ]
+  files: files
 }
 
 GalleryStory.storyName = 'Gallery'
+
+export const GalleryStoryVariantQuilted: StoryFn<GalleryProps> = (
+  args: GalleryProps
+) => {
+  return (
+    <Box
+      sx={{
+        width: '400px',
+        height: '500px'
+      }}
+    >
+      <Gallery
+        gridProps={{
+          cols: 1,
+          variant: 'quilted'
+        }}
+        {...args}
+      />
+    </Box>
+  )
+}
+GalleryStoryVariantQuilted.args = {
+  files: files
+}
+
+GalleryStoryVariantQuilted.storyName = 'Gallery Quilted'

--- a/packages/fs/src/Gallery/Components/Gallery/Gallery.tsx
+++ b/packages/fs/src/Gallery/Components/Gallery/Gallery.tsx
@@ -2,8 +2,7 @@ import { ImageList, ImageListItem, Stack } from '@mui/material'
 import React, { useMemo } from 'react'
 import { FsFile } from '../../Domain'
 import { cx } from '@emotion/css'
-import { BasicProps, MergeMuiElementProps } from '@komune-io/g2-themes'
-import { AutoCompleteProps } from '@komune-io/g2-forms'
+import { BasicProps } from '@komune-io/g2-themes'
 import { ImageListProps } from '@mui/material/ImageList/ImageList'
 
 export interface GalleryClasses {
@@ -16,10 +15,7 @@ export interface GalleryStyles {
   item?: React.CSSProperties
 }
 
-export type GridProps<T = any> = MergeMuiElementProps<
-  ImageListProps,
-  AutoCompleteProps<T>
->
+export type GridProps = Omit<ImageListProps, 'children'>
 
 export interface GalleryProps extends BasicProps {
   /**


### PR DESCRIPTION
The Gallery component now supports displaying multiple files by introducing an array of FsFile objects. This change enhances the flexibility and scalability of the Gallery component, allowing it to showcase a variety of images. Additionally, a new story variant 'Gallery Quilted' has been added to demonstrate a different layout option for the Gallery component.