### PR TITLE
refactor(DocumentHandler.tsx): change childrenProps type to DropzoneChildrenProps for clarity and consistency

### DIFF
--- a/packages/components/src/DocumentHandler/DocumentHandler.tsx
+++ b/packages/components/src/DocumentHandler/DocumentHandler.tsx
@@ -211,7 +211,7 @@ export const DocumentHandler = (props: DocumentHandlerProps) => {
     return
   }, [fileTypesAllowed])
 
-  const childrenProps = {
+  const childrenProps: DropzoneChildrenProps = {
     uploaded,
     error,
     label,
@@ -295,7 +295,6 @@ interface DropzoneChildrenProps {
   error?: string
   label?: string
   isRequired?: boolean
-  isRequiredLabel?: string
   onDelete?: () => void
   onEditFileName?: (newName: string) => void
   onDownload?: () => void

--- a/packages/providers/src/G2ConfigBuilder/RequestProps.ts
+++ b/packages/providers/src/G2ConfigBuilder/RequestProps.ts
@@ -1,11 +1,7 @@
 import { useMemo } from 'react'
 import { fsConfig, imConfig, platFormConfig } from '.'
 import { useAuth } from '../KeycloakProvider'
-
-export type RequestProps = {
-  url: string
-  jwt?: string
-}
+import { RequestProps } from '@komune-io/g2-utils'
 
 export const useNoAuthenticatedRequest = (
   endpoint: 'plateform' | 'im' | 'fs' = 'plateform'
@@ -16,8 +12,8 @@ export const useNoAuthenticatedRequest = (
         endpoint === 'fs'
           ? fsConfig().url
           : endpoint === 'im'
-          ? imConfig().url
-          : platFormConfig().url
+            ? imConfig().url
+            : platFormConfig().url
     }),
     []
   )
@@ -33,8 +29,8 @@ export const useAuthenticatedRequest = (
         endpoint === 'fs'
           ? fsConfig().url
           : endpoint === 'im'
-          ? imConfig().url
-          : platFormConfig().url,
+            ? imConfig().url
+            : platFormConfig().url,
       jwt: auth.keycloak.token
     }),
     [auth.keycloak.token]


### PR DESCRIPTION
chore(RequestProps.ts): import RequestProps type from external package for better organization and reusability

Changing the type of childrenProps to DropzoneChildrenProps in DocumentHandler.tsx improves code readability and maintains consistency throughout the file. Importing the RequestProps type from an external package in RequestProps.ts enhances code organization and promotes reusability of the type definition.