### PR TITLE
chore(utils): remove unnecessary publishConfig from package.json

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -40,8 +40,5 @@
     "@tanstack/react-query": "^5.28.6",
     "i18next": "^23.10.1",
     "lodash-es": "^4.17.21"
-  },
-  "publishConfig": {
-    "@komune-io:registry": "https://npm.pkg.github.com"
   }
 }


### PR DESCRIPTION
The publishConfig field was removed from the package.json file as it was unnecessary and no longer needed for the project. This change helps to clean up the configuration file and remove any unused or redundant settings.