### PR TITLE
refactor roles transformation logic into a separate helper function transformRoles

### DIFF
--- a/packages/im/src/User/Components/UserFactory/useUserFormState.ts
+++ b/packages/im/src/User/Components/UserFactory/useUserFormState.ts
@@ -204,7 +204,7 @@ export const useUserFormState = <T extends User = User>(
       if (onSubmit) {
         await onSubmit({
           ...values,
-          ...flatUserToUser(values, multipleRoles),
+          ...flatUserToUser(values),
           id: user?.id ?? '',
           phone: values.phone?.replaceAll(' ', '')
         } as T)

--- a/packages/im/src/User/Domain/index.ts
+++ b/packages/im/src/User/Domain/index.ts
@@ -61,10 +61,7 @@ export const userToFlatUser = (user: User): FlatUser => {
   return flat
 }
 
-export const flatUserToUser = (
-  flat: FlatUser,
-  multipleRoles: boolean
-): User => {
+export const flatUserToUser = (flat: FlatUser): User => {
   // @ts-ignore
   const user: User & {
     street?: string
@@ -82,8 +79,7 @@ export const flatUserToUser = (
       name: '',
       roles: []
     },
-    // @ts-ignore
-    roles: multipleRoles ? flat.roles : [flat.roles]
+    roles: transformRoles(flat.roles)
   }
   delete user.street
   delete user.city
@@ -124,4 +120,27 @@ export interface UserUpdateEmailCommand {
 
 export interface UserUpdatedEmailEvent {
   id: UserId
+}
+
+type WithId = { id: string }
+
+function transformRoles(
+  roles: WithId | WithId[] | string | string[] | undefined
+): string[] {
+  if (roles === undefined) {
+    return []
+  }
+
+  // Wrap roles in an array if it's not already an array
+  const rolesArray = Array.isArray(roles) ? roles : [roles]
+
+  // Flatten the roles array and transform objects with id property to their id string
+  return rolesArray.map((role) => {
+    if (typeof role === 'string') {
+      return role
+    } else if (typeof role === 'object' && 'id' in role) {
+      return role.id
+    }
+    return ''
+  })
 }

--- a/packages/im/src/User/Domain/index.ts
+++ b/packages/im/src/User/Domain/index.ts
@@ -122,10 +122,10 @@ export interface UserUpdatedEmailEvent {
   id: UserId
 }
 
-type WithId = { id: string }
+type WithIdentifier = { identifier: string }
 
 function transformRoles(
-  roles: WithId | WithId[] | string | string[] | undefined
+  roles: WithIdentifier | WithIdentifier[] | string | string[] | undefined
 ): string[] {
   if (roles === undefined) {
     return []
@@ -138,8 +138,8 @@ function transformRoles(
   return rolesArray.map((role) => {
     if (typeof role === 'string') {
       return role
-    } else if (typeof role === 'object' && 'id' in role) {
-      return role.id
+    } else if (typeof role === 'object') {
+      return role.identifier
     }
     return ''
   })


### PR DESCRIPTION
The multipleRoles parameter in the flatUserToUser function is no longer needed and has been removed to simplify the function signature. The roles transformation logic has been refactored into a separate helper function transformRoles to improve code readability and maintainability. This helper function handles transforming roles into an array of strings, handling different input types and formats.