### PR TITLE
Add onFieldChange Handling with FormComposableState for Improved Form Management

### DIFF
--- a/packages/composable/src/AutoForm/AutoForm.stories.tsx
+++ b/packages/composable/src/AutoForm/AutoForm.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Meta, StoryFn } from '@storybook/react'
 import {
   ArgsTable,
@@ -8,7 +8,7 @@ import {
   Title,
   Subtitle
 } from '@storybook/addon-docs'
-import { AutoForm, AutoFormProps } from './AutoForm'
+import { AutoForm, AutoFormData, AutoFormProps } from './AutoForm'
 import { BrowserRouter } from 'react-router-dom'
 // @ts-ignore
 import json from './autoForm.json'
@@ -16,6 +16,8 @@ import { autoFormFormatter } from './autoFormFormatter'
 import { Button } from '@komune-io/g2-components'
 import { Box, Stack, Typography } from '@mui/material'
 import LinkTo from '@storybook/addon-links/react'
+import { useAutoForm } from './useAutoForm'
+import { FormComposableState } from '../FormComposable'
 
 export default {
   title: 'Composable/AutoForm',
@@ -82,9 +84,63 @@ export const AutoFormStory: StoryFn<AutoFormProps> = (args: AutoFormProps) => {
   )
 }
 
-const formData = autoFormFormatter(json)
-console.log(formData)
+export const OnChangeVariant: StoryFn = () => {
+  const charLimit = 20
+  const formData = useMemo(
+    (): AutoFormData => ({
+      sections: [
+        {
+          id: 'sectionCreation',
+          fields: [
+            {
+              label: 'Name',
+              name: 'title',
+              type: 'textField',
+              required: true,
+              onChange: (value: any, formState: FormComposableState) => {
+                if (value.length <= charLimit)
+                  formState.setFieldValue('title', value)
+              },
+              params: {
+                multiline: true,
+                rows: 2,
+                createInputContainer: (input) => (
+                  <Stack gap={2}>
+                    {input}
+                    <Typography
+                      variant='caption'
+                      sx={{
+                        alignSelf: 'flex-end'
+                      }}
+                    >
+                      {`${input.props.value.length}/${charLimit}`}
+                    </Typography>
+                  </Stack>
+                )
+              }
+            }
+          ]
+        }
+      ]
+    }),
+    []
+  )
+
+  const { form } = useAutoForm({
+    data: formData,
+    initialValues: {},
+    actions: (formState) => (
+      <Button onClick={formState.submitForm}>Submit</Button>
+    ),
+    onSubmit: async (values: undefined) => {
+      console.log(values)
+    }
+  })
+  return form
+}
+
+OnChangeVariant.storyName = 'OnChange'
 
 AutoFormStory.args = {
-  formData: formData
+  formData: autoFormFormatter(json)
 }

--- a/packages/composable/src/AutoForm/AutoForm.stories.tsx
+++ b/packages/composable/src/AutoForm/AutoForm.stories.tsx
@@ -97,7 +97,7 @@ export const OnChangeVariant: StoryFn = () => {
               name: 'title',
               type: 'textField',
               required: true,
-              onChange: (value: any, formState: FormComposableState) => {
+              onValueChange: (value: any, formState: FormComposableState) => {
                 if (value.length <= charLimit)
                   formState.setFieldValue('title', value)
               },

--- a/packages/composable/src/FormComposable/elements/AutoCompleteRender.tsx
+++ b/packages/composable/src/FormComposable/elements/AutoCompleteRender.tsx
@@ -7,6 +7,7 @@ import React, { useMemo } from 'react'
 import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getValueSetup } from '../type/getValueSetup'
+import { useChangeHandler } from '../type/useChangeHandler'
 
 export type AutoCompleteExtendProps = Partial<
   Omit<
@@ -31,24 +32,25 @@ export const AutoCompleteRender: ElementRendererFunction<
 > = (props: AutoCompleteRenderProps) => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const componentProps = { ...basicProps }
-  const onChange = componentProps.onChange
-
+  const { onChange, onValueChange, emptyValueInReadOnly, ...componentProps } =
+    basicProps
   const { value, setFieldValue } = useMemo(
     () => getValueSetup(componentProps.name, formState),
     [componentProps.name, formState]
   )
-  delete componentProps.onChange
+  const onChangeHandler = useChangeHandler(
+    formState,
+    setFieldValue,
+    onChange,
+    onValueChange
+  )
 
   return params?.multiple === true ? (
     // @ts-ignore
     <InputForm
       inputType='autoComplete'
       values={value ?? []}
-      onChangeValues={(values: any) => {
-        setFieldValue(values)
-        !!onChange && onChange(values)
-      }}
+      onChangeValues={onChangeHandler}
       {...params}
       {...componentProps}
     />
@@ -57,10 +59,7 @@ export const AutoCompleteRender: ElementRendererFunction<
     <InputForm
       inputType='autoComplete'
       value={value ?? null}
-      onChangeValue={(value: any) => {
-        setFieldValue(value)
-        !!onChange && onChange(value)
-      }}
+      onChangeValue={onChangeHandler}
       {...params}
       {...componentProps}
     />

--- a/packages/composable/src/FormComposable/elements/CheckBoxRender.tsx
+++ b/packages/composable/src/FormComposable/elements/CheckBoxRender.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react'
 import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getValueSetup } from '../type/getValueSetup'
+import { useChangeHandler } from '../type/useChangeHandler'
 
 export type CheckBoxExtendProps = Partial<
   Omit<CheckBoxProps, 'checked' | 'onChange' | 'label' | 'classes' | 'styles'>
@@ -18,22 +19,26 @@ export const CheckBoxRender: ElementRendererFunction<CheckBoxRenderProps> = (
 ) => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const componentProps = { ...basicProps }
-  delete componentProps.emptyValueInReadOnly
+
+  const { onChange, onValueChange, emptyValueInReadOnly, ...componentProps } =
+    basicProps
   const { value, setFieldValue } = useMemo(
     () => getValueSetup(componentProps.name, formState),
     [componentProps.name, formState]
   )
-  const onChange = componentProps.onChange
-  delete componentProps.onChange
+  const onChangeHandler = useChangeHandler(
+    formState,
+    setFieldValue,
+    onChange,
+    onValueChange
+  )
 
   return (
     <CheckBox
       checked={value}
       disabled={params?.disabled}
       onChange={(_: React.ChangeEvent<HTMLInputElement>, value: boolean) => {
-        setFieldValue(value)
-        !!onChange && onChange(value)
+        onChangeHandler(value)
       }}
       {...params}
       {...componentProps}

--- a/packages/composable/src/FormComposable/elements/DatePickerRender.tsx
+++ b/packages/composable/src/FormComposable/elements/DatePickerRender.tsx
@@ -35,7 +35,7 @@ export const DatePickerRender: ElementRendererFunction<
 
   const onChangeHandler = useCallback(
     (date?: Date) => {
-      if (!!onValueChange) {
+      if (onValueChange) {
         onValueChange(value, formState)
       } else {
         date && !isNaN(date.getTime()) ? date.getTime() : date?.toString()

--- a/packages/composable/src/FormComposable/elements/DatePickerRender.tsx
+++ b/packages/composable/src/FormComposable/elements/DatePickerRender.tsx
@@ -3,7 +3,7 @@ import {
   DatePickerProps,
   InputForm
 } from '@komune-io/g2-forms'
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getValueSetup } from '../type/getValueSetup'
@@ -25,25 +25,31 @@ export const DatePickerRender: ElementRendererFunction<
 > = (props: DatePickerRenderProps) => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const componentProps = { ...basicProps }
+
+  const { onChange, onValueChange, ...componentProps } = basicProps
   const { value, setFieldValue } = useMemo(
     () => getValueSetup(componentProps.name, formState),
     [componentProps.name, formState]
   )
   const date = new Date(value)
-  const onChange = componentProps.onChange
-  delete componentProps.onChange
+
+  const onChangeHandler = useCallback(
+    (date?: Date) => {
+      if (!!onValueChange) {
+        onValueChange(value, formState)
+      } else {
+        date && !isNaN(date.getTime()) ? date.getTime() : date?.toString()
+        !!onChange && onChange(value)
+      }
+    },
+    [formState, setFieldValue, onChange, onValueChange]
+  )
 
   return (
     <InputForm
       inputType='datePicker'
       value={!isNaN(date.getTime()) ? date : value ?? ''}
-      onChangeDate={(date) => {
-        setFieldValue(
-          date && !isNaN(date.getTime()) ? date.getTime() : date?.toString()
-        )
-        !!onChange && onChange(date)
-      }}
+      onChangeDate={onChangeHandler}
       {...params}
       {...componentProps}
     />

--- a/packages/composable/src/FormComposable/elements/DocumentHandlerRender.tsx
+++ b/packages/composable/src/FormComposable/elements/DocumentHandlerRender.tsx
@@ -4,6 +4,7 @@ import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getIn } from 'formik'
 import { Box } from '@mui/material'
+import { useChangeHandler } from '../type/useChangeHandler'
 
 export type DocumentHandlerExtendProps = Partial<
   Omit<
@@ -22,9 +23,25 @@ export const DocumentHandlerRender: ElementRendererFunction<
 > = (props: DocumentHandlerRenderProps) => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const { errorMessage, label, onChange, readOnly, sx, ...basicPropsRest } =
-    basicProps
+  const {
+    errorMessage,
+    label,
+    onChange,
+    onValueChange,
+    readOnly,
+    sx,
+    ...basicPropsRest
+  } = basicProps
   delete basicProps.emptyValueInReadOnly
+
+  const setFieldValue = (files: File[]) =>
+    formState.setFieldValue(basicProps.name, files[0], false)
+  const onChangeHandler = useChangeHandler(
+    formState,
+    setFieldValue,
+    onChange,
+    onValueChange
+  )
 
   const localFile: File | undefined = getIn(formState.values, basicProps.name)
   const uploadedGetUrl = getIn(formState.values, basicProps.name + 'Uploaded')
@@ -39,10 +56,7 @@ export const DocumentHandlerRender: ElementRendererFunction<
         getFileUrl={
           localFile ? () => URL.createObjectURL(localFile) : uploadedGetUrl
         }
-        onAdd={(files: File[]) => {
-          formState.setFieldValue(basicProps.name, files[0], false)
-          !!onChange && onChange(files[0])
-        }}
+        onAdd={onChangeHandler}
         onDelete={
           !basicProps.readOnly
             ? () => {

--- a/packages/composable/src/FormComposable/elements/DropPictureRender.tsx
+++ b/packages/composable/src/FormComposable/elements/DropPictureRender.tsx
@@ -4,6 +4,7 @@ import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getIn } from 'formik'
 import { Box, InputLabel } from '@mui/material'
+import { useChangeHandler } from '../type/useChangeHandler'
 
 export type DropPictureExtendProps = Partial<
   Omit<
@@ -22,8 +23,15 @@ export const DropPictureRender: ElementRendererFunction<
 > = (props: DropPictureRenderProps) => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const { errorMessage, onChange, sx, label, id, ...basicPropsRest } =
-    basicProps
+  const {
+    errorMessage,
+    onChange,
+    onValueChange,
+    sx,
+    label,
+    id,
+    ...basicPropsRest
+  } = basicProps
   delete basicProps.emptyValueInReadOnly
 
   const localFile: File | undefined = getIn(formState.values, basicProps.name)
@@ -32,16 +40,23 @@ export const DropPictureRender: ElementRendererFunction<
     basicProps.name + 'Uploaded'
   )
   if (basicProps.readOnly && !uploadedGetUrl && !localFile) return <></>
+
+  const setFieldValue = (file: File) =>
+    formState.setFieldValue(basicProps.name, file, false)
+  const onChangeHandler = useChangeHandler(
+    formState,
+    setFieldValue,
+    onChange,
+    onValueChange
+  )
+
   return (
     <Box sx={sx}>
       {label && <InputLabel htmlFor={id}>{label}</InputLabel>}
       <DropPicture
         id={id}
         pictureUrl={localFile ? URL.createObjectURL(localFile) : uploadedGetUrl}
-        onPictureDropped={(picture: File) => {
-          formState.setFieldValue(basicProps.name, picture, false)
-          !!onChange && onChange(picture)
-        }}
+        onPictureDropped={onChangeHandler}
         onRemovePicture={
           !basicProps.readOnly
             ? () => {

--- a/packages/composable/src/FormComposable/elements/DropPictureRender.tsx
+++ b/packages/composable/src/FormComposable/elements/DropPictureRender.tsx
@@ -39,7 +39,6 @@ export const DropPictureRender: ElementRendererFunction<
     formState.values,
     basicProps.name + 'Uploaded'
   )
-  if (basicProps.readOnly && !uploadedGetUrl && !localFile) return <></>
 
   const setFieldValue = (file: File) =>
     formState.setFieldValue(basicProps.name, file, false)
@@ -49,6 +48,8 @@ export const DropPictureRender: ElementRendererFunction<
     onChange,
     onValueChange
   )
+
+  if (basicProps.readOnly && !uploadedGetUrl && !localFile) return <></>
 
   return (
     <Box sx={sx}>

--- a/packages/composable/src/FormComposable/elements/HiddenRender.tsx
+++ b/packages/composable/src/FormComposable/elements/HiddenRender.tsx
@@ -16,7 +16,7 @@ export const HiddenRender: ElementRendererFunction<HiddenRenderProps> = (
   const { params } = element
 
   const { onChange, onValueChange, ...componentProps } = basicProps
-  const { setFieldValue } = useMemo(
+  const { value, setFieldValue } = useMemo(
     () => getValueSetup(componentProps.name, formState),
     [componentProps.name, formState]
   )
@@ -30,5 +30,12 @@ export const HiddenRender: ElementRendererFunction<HiddenRenderProps> = (
     onChangeHandler(e.target.value)
   }
 
-  return <input onChange={changeEventHandler} type='hidden' {...params} />
+  return (
+    <input
+      value={value ?? ''}
+      onChange={changeEventHandler}
+      type='hidden'
+      {...params}
+    />
+  )
 }

--- a/packages/composable/src/FormComposable/elements/HiddenRender.tsx
+++ b/packages/composable/src/FormComposable/elements/HiddenRender.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo } from 'react'
+import React, { ChangeEventHandler, useMemo } from 'react'
 import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getValueSetup } from '../type/getValueSetup'
+import { useChangeHandler } from '../type/useChangeHandler'
 
 export type HiddenRenderProps = FieldRenderProps<
   'hidden',
@@ -13,14 +14,21 @@ export const HiddenRender: ElementRendererFunction<HiddenRenderProps> = (
 ) => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const componentProps = { ...basicProps }
 
-  const { value } = useMemo(
+  const { onChange, onValueChange, ...componentProps } = basicProps
+  const { setFieldValue } = useMemo(
     () => getValueSetup(componentProps.name, formState),
     [componentProps.name, formState]
   )
+  const onChangeHandler = useChangeHandler(
+    formState,
+    setFieldValue,
+    onChange,
+    onValueChange
+  )
+  const changeEventHandler: ChangeEventHandler<HTMLInputElement> = (e) => {
+    onChangeHandler(e.target.value)
+  }
 
-  delete componentProps.onChange
-
-  return <input value={value ?? ''} type='hidden' {...params} />
+  return <input onChange={changeEventHandler} type='hidden' {...params} />
 }

--- a/packages/composable/src/FormComposable/elements/MapComposableRenderer.tsx
+++ b/packages/composable/src/FormComposable/elements/MapComposableRenderer.tsx
@@ -33,13 +33,15 @@ export const MapComposableRenderer: ElementRendererFunction<
     () => getIn(formState.values, basicProps.name),
     [formState.values, basicProps.name]
   )
-  const onChange = basicProps.onChange
-  delete basicProps.onChange
-  delete basicProps.emptyValueInReadOnly
 
-  //@ts-ignore
-  delete basicProps.error
-  delete basicProps.isLoading
+  const {
+    onChange,
+    onValueChange,
+    emptyValueInReadOnly,
+    error,
+    isLoading,
+    ...componentProps
+  } = basicProps
 
   const pluginsCount =
     (params?.additionalPlugins?.length ?? 0) +
@@ -47,12 +49,17 @@ export const MapComposableRenderer: ElementRendererFunction<
 
   const onChangeMapState = useCallback(
     (key: string, value: any) => {
-      formState.setFieldValue(
-        basicProps.name,
-        pluginsCount > 1 ? { ...mapState, [key]: value } : value
-      )
+      if (onValueChange) {
+        onValueChange(value, formState)
+      } else {
+        formState.setFieldValue(
+          componentProps.name,
+          pluginsCount > 1 ? { ...mapState, [key]: value } : value
+        )
+        onChange && onChange(value)
+      }
     },
-    [onChange, mapState, formState.setFieldValue, pluginsCount]
+    [mapState, formState.setFieldValue, pluginsCount]
   )
 
   const additionalPlugins = useMemo(
@@ -73,7 +80,7 @@ export const MapComposableRenderer: ElementRendererFunction<
 
   return (
     <Map
-      {...basicProps}
+      {...componentProps}
       {...params}
       additionalPlugins={additionalPlugins}
       draggableMarkerPlugin={

--- a/packages/composable/src/FormComposable/elements/MultiChoicesRender.tsx
+++ b/packages/composable/src/FormComposable/elements/MultiChoicesRender.tsx
@@ -7,6 +7,7 @@ import {
 import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getValueSetup } from '../type/getValueSetup'
+import { useChangeHandler } from '../type/useChangeHandler'
 
 export type MultiChoicesExtendProps = Partial<
   Omit<
@@ -25,13 +26,17 @@ export const MultiChoicesRender: ElementRendererFunction<
 > = (props: MultiChoicesRenderProps): ReactElement => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const componentProps = { ...basicProps }
+  const { onChange, onValueChange, ...componentProps } = basicProps
   const { value, setFieldValue } = useMemo(
     () => getValueSetup(componentProps.name, formState),
     [componentProps.name, formState]
   )
-  const onChange = componentProps.onChange
-  delete componentProps.onChange
+  const onChangeHandler = useChangeHandler(
+    formState,
+    setFieldValue,
+    onChange,
+    onValueChange
+  )
 
   return (
     <InputForm
@@ -39,10 +44,7 @@ export const MultiChoicesRender: ElementRendererFunction<
       values={value ?? ''}
       {...params}
       {...componentProps}
-      onChange={(values) => {
-        setFieldValue(values)
-        !!onChange && onChange(values)
-      }}
+      onChange={onChangeHandler}
     />
   )
 }

--- a/packages/composable/src/FormComposable/elements/RadioChoicesRender.tsx
+++ b/packages/composable/src/FormComposable/elements/RadioChoicesRender.tsx
@@ -7,6 +7,7 @@ import {
 import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getValueSetup } from '../type/getValueSetup'
+import { useChangeHandler } from '../type/useChangeHandler'
 
 export type RadioChoicesExtendProps = Partial<
   Omit<
@@ -25,13 +26,17 @@ export const RadioChoicesRender: ElementRendererFunction<
 > = (props: RadioChoicesRenderProps): ReactElement => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const componentProps = { ...basicProps }
+  const { onChange, onValueChange, ...componentProps } = basicProps
   const { value, setFieldValue } = useMemo(
     () => getValueSetup(componentProps.name, formState),
     [componentProps.name, formState]
   )
-  const onChange = componentProps.onChange
-  delete componentProps.onChange
+  const onChangeHandler = useChangeHandler(
+    formState,
+    setFieldValue,
+    onChange,
+    onValueChange
+  )
 
   return (
     <InputForm
@@ -39,10 +44,7 @@ export const RadioChoicesRender: ElementRendererFunction<
       value={value ?? ''}
       {...params}
       {...componentProps}
-      onChange={(value: string) => {
-        setFieldValue(value)
-        !!onChange && onChange(value)
-      }}
+      onChange={onChangeHandler}
     />
   )
 }

--- a/packages/composable/src/FormComposable/elements/SelectRender.tsx
+++ b/packages/composable/src/FormComposable/elements/SelectRender.tsx
@@ -7,6 +7,7 @@ import {
 import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getValueSetup } from '../type/getValueSetup'
+import { useChangeHandler } from '../type/useChangeHandler'
 
 export type FormSelectExtendProps = Partial<
   Omit<
@@ -31,22 +32,23 @@ export const SelectRender: ElementRendererFunction<SelectRenderProps> = (
 ): ReactElement => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const componentProps = { ...basicProps }
+  const { onChange, onValueChange, ...componentProps } = basicProps
   const { value, setFieldValue } = useMemo(
     () => getValueSetup(componentProps.name, formState),
     [componentProps.name, formState]
   )
-  const onChange = componentProps.onChange
-  delete componentProps.onChange
+  const onChangeHandler = useChangeHandler(
+    formState,
+    setFieldValue,
+    onChange,
+    onValueChange
+  )
 
   return params?.multiple === true ? (
     <InputForm
       inputType='select'
       values={value ?? []}
-      onChangeValues={(values: string[]) => {
-        setFieldValue(values)
-        !!onChange && onChange(values)
-      }}
+      onChangeValues={onChangeHandler}
       {...params}
       {...componentProps}
     />

--- a/packages/composable/src/FormComposable/elements/TextFieldRender.tsx
+++ b/packages/composable/src/FormComposable/elements/TextFieldRender.tsx
@@ -7,6 +7,7 @@ import React, { useMemo } from 'react'
 import { FieldRenderProps } from '../type'
 import { ElementRendererFunction } from '../../ComposableRender'
 import { getValueSetup } from '../type/getValueSetup'
+import { useChangeHandler } from '../type/useChangeHandler'
 
 export type TextFieldExtendProps = Partial<
   Omit<
@@ -25,24 +26,24 @@ export const TextFieldRender: ElementRendererFunction<TextFieldRenderProps> = (
 ) => {
   const { element, formState, basicProps } = props
   const { params } = element
-  const componentProps = { ...basicProps }
-  const onChange = componentProps.onChange
 
+  const { onChange, onValueChange, ...componentProps } = basicProps
   const { value, setFieldValue } = useMemo(
     () => getValueSetup(componentProps.name, formState),
     [componentProps.name, formState]
   )
-
-  delete componentProps.onChange
+  const onChangeHandler = useChangeHandler(
+    formState,
+    setFieldValue,
+    onChange,
+    onValueChange
+  )
 
   return (
     <InputForm
       inputType='textField'
       value={value ?? ''}
-      onChange={(value: string) => {
-        setFieldValue(value)
-        !!onChange && onChange(value)
-      }}
+      onChange={onChangeHandler}
       {...params}
       {...componentProps}
     />

--- a/packages/composable/src/FormComposable/type/FieldRenderProps.ts
+++ b/packages/composable/src/FormComposable/type/FieldRenderProps.ts
@@ -2,7 +2,11 @@ import { WithElementParams } from '../../ComposableRender'
 import { FormComposableState } from './FormComposableState'
 import { FormComposableProps } from '../FormComposable'
 import { useEffect, useMemo } from 'react'
-import { FormComposableField } from './FormComposableField'
+import {
+  FormComposableField,
+  OnChangeFnc,
+  OnValueChangeFnc
+} from './FormComposableField'
 import { cx } from '@emotion/css'
 import { getIn } from 'formik'
 import { SxProps, Theme } from '@mui/material'
@@ -41,7 +45,8 @@ export interface FieldRender {
    */
   readOnly?: boolean
   sx?: SxProps<Theme>
-  onChange?: (value: any) => void
+  onChange?: OnChangeFnc
+  onValueChange?: OnValueChangeFnc
   emptyValueInReadOnly?: any
 }
 
@@ -82,12 +87,13 @@ const getFormProps = (
         }
       : undefined,
     onChange: field.onChange,
+    onValueChange: field.onValueChange,
     readOnly:
       field.readOnly === true
         ? field.readOnly
         : readOnly === true
-        ? readOnly
-        : formState.readOnly,
+          ? readOnly
+          : formState.readOnly,
 
     emptyValueInReadOnly:
       //@ts-ignore

--- a/packages/composable/src/FormComposable/type/FormComposableField.ts
+++ b/packages/composable/src/FormComposable/type/FormComposableField.ts
@@ -6,8 +6,14 @@ import {
 import { ReactNode } from 'react'
 import { PotentialError } from '@komune-io/g2-forms'
 import { Condition } from '../../Conditions'
+import { FormComposableState } from './FormComposableState'
 
 export type FieldValidatorFnc = (value?: any, values?: any) => PotentialError
+export type OnChangeFnc = (value: any) => void
+export type OnValueChangeFnc = (
+  value: any,
+  formState: FormComposableState
+) => void
 
 export interface CommonFieldProps<Name extends string = string> {
   /**
@@ -50,9 +56,16 @@ export interface CommonFieldProps<Name extends string = string> {
    */
   fullRow?: boolean
   /**
-   * the event called when the value of the input change
+   * Event handler called when the value of the input changes.
+   * The new value is automatically set in the form state.
    */
-  onChange?: (value: any) => void
+  onChange?: OnChangeFnc
+  /**
+   * Event handler called when the value of the input changes.
+   * The new value is not set in the form state.
+   * The `onChange` event will not be called.
+   */
+  onValueChange?: OnValueChangeFnc
   /**
    * Indicates if the data is on readOnly mode
    *

--- a/packages/composable/src/FormComposable/type/getValueSetup.ts
+++ b/packages/composable/src/FormComposable/type/getValueSetup.ts
@@ -1,13 +1,35 @@
 import { getIn } from 'formik'
 import { FormComposableState } from './FormComposableState'
 
-export type SetFieldValue = (newValue: any) => void
+/**
+ * Function type for setting a new value in the form state.
+ *
+ * @param newValue - The new value to set in the form state.
+ */
+export type SetFieldValueFnc = (newValue: any) => void
 
+/**
+ * Interface representing the return value of the `getValueSetup` function.
+ */
 export interface GetValueSetupReturn {
+  /**
+   * The current value from the form state.
+   */
   value: any
-  setFieldValue: SetFieldValue
+
+  /**
+   * Function to set a new value in the form state.
+   */
+  setFieldValue: SetFieldValueFnc
 }
 
+/**
+ * Retrieves the current value from the form state and provides a function to set a new value.
+ *
+ * @param name - The name of the field in the form state.
+ * @param formState - The current state of the form.
+ * @returns An object containing the current value and a function to set a new value.
+ */
 export const getValueSetup = (
   name: string,
   formState: FormComposableState

--- a/packages/composable/src/FormComposable/type/getValueSetup.ts
+++ b/packages/composable/src/FormComposable/type/getValueSetup.ts
@@ -23,7 +23,7 @@ export interface GetValueSetupReturn {
   setFieldValue: SetFieldValueFnc
 }
 
-/**
+/**`
  * Retrieves the current value from the form state and provides a function to set a new value.
  *
  * @param name - The name of the field in the form state.

--- a/packages/composable/src/FormComposable/type/getValueSetup.ts
+++ b/packages/composable/src/FormComposable/type/getValueSetup.ts
@@ -1,7 +1,17 @@
 import { getIn } from 'formik'
 import { FormComposableState } from './FormComposableState'
 
-export const getValueSetup = (name: string, formState: FormComposableState) => {
+export type SetFieldValue = (newValue: any) => void
+
+export interface GetValueSetupReturn {
+  value: any
+  setFieldValue: SetFieldValue
+}
+
+export const getValueSetup = (
+  name: string,
+  formState: FormComposableState
+): GetValueSetupReturn => {
   const value = getIn(formState.values, name)
   return {
     value: value,

--- a/packages/composable/src/FormComposable/type/useChangeHandler.ts
+++ b/packages/composable/src/FormComposable/type/useChangeHandler.ts
@@ -11,7 +11,7 @@ export const useChangeHandler = <T>(
 ) => {
   return useCallback(
     (value: T) => {
-      if (!!onValueChange) {
+      if (onValueChange) {
         onValueChange(value, formState)
       } else {
         setFieldValue(value)

--- a/packages/composable/src/FormComposable/type/useChangeHandler.ts
+++ b/packages/composable/src/FormComposable/type/useChangeHandler.ts
@@ -1,0 +1,23 @@
+import { FormComposableState } from './FormComposableState'
+import { SetFieldValue } from './getValueSetup'
+import { OnChangeFnc, OnValueChangeFnc } from './FormComposableField'
+import { useCallback } from 'react'
+
+export const useChangeHandler = <T>(
+  formState: FormComposableState,
+  setFieldValue: SetFieldValue,
+  onChange?: OnChangeFnc,
+  onValueChange?: OnValueChangeFnc
+) => {
+  return useCallback(
+    (value: T) => {
+      if (!!onValueChange) {
+        onValueChange(value, formState)
+      } else {
+        setFieldValue(value)
+        !!onChange && onChange(value)
+      }
+    },
+    [formState, setFieldValue, onChange, onValueChange]
+  )
+}

--- a/packages/composable/src/FormComposable/type/useChangeHandler.ts
+++ b/packages/composable/src/FormComposable/type/useChangeHandler.ts
@@ -1,11 +1,11 @@
 import { FormComposableState } from './FormComposableState'
-import { SetFieldValue } from './getValueSetup'
+import { SetFieldValueFnc } from './getValueSetup'
 import { OnChangeFnc, OnValueChangeFnc } from './FormComposableField'
 import { useCallback } from 'react'
 
 export const useChangeHandler = <T>(
   formState: FormComposableState,
-  setFieldValue: SetFieldValue,
+  setFieldValue: SetFieldValueFnc,
   onChange?: OnChangeFnc,
   onValueChange?: OnValueChangeFnc
 ) => {


### PR DESCRIPTION
- Introduced `useChangeHandler` hook to manage form state changes centrally, enhancing flexibility and reducing code duplication across multiple form elements.
- Updated `onChange` handling to include `formState` in `TextFieldRender` and other components, improving state management and type safety.
- Refactored form components to standardize change handling logic, resulting in better maintainability, readability, and extensibility of the codebase.