### PR TITLE
fix(layout): correct typo in PermanentHeader variable name

### DIFF
--- a/packages/layout/src/StandAloneAppLayout/StandAloneAppLayout.tsx
+++ b/packages/layout/src/StandAloneAppLayout/StandAloneAppLayout.tsx
@@ -156,14 +156,14 @@ export const StandAloneAppLayout = (props: StandAloneAppLayoutProps) => {
 
   const currentOpen = open !== undefined ? open : openDrawer
 
-  const PerManentHeader = useMemo(
+  const PermanentHeader = useMemo(
     () => g2Theme.permanentHeader,
     [g2Theme.permanentHeader]
   )
 
   return (
     <>
-      {PerManentHeader && (
+      {PermanentHeader && (
         <Box
           sx={{
             position: 'fixed',
@@ -173,7 +173,7 @@ export const StandAloneAppLayout = (props: StandAloneAppLayoutProps) => {
             width: g2Theme.drawerWidth
           }}
         >
-          <PerManentHeader
+          <PermanentHeader
             toggleOpenDrawer={toggleOpenDrawer}
             openDrawer={currentOpen}
           />
@@ -215,7 +215,7 @@ export const StandAloneAppLayout = (props: StandAloneAppLayoutProps) => {
                 : 'white',
             paddingTop: drawerPaddingTop
               ? drawerPaddingTop
-              : PerManentHeader
+              : PermanentHeader
                 ? '90px'
                 : undefined
           },

--- a/packages/themes/src/ThemeContextProvider/Theme.tsx
+++ b/packages/themes/src/ThemeContextProvider/Theme.tsx
@@ -6,6 +6,7 @@ import {
 } from '@mui/material'
 import tinycolor from 'tinycolor2'
 import { mergeDeepRight } from 'ramda'
+import { PermanentHeaderThemeProps } from './ThemeContextProvider'
 
 export interface Theme {
   name?: string
@@ -19,7 +20,7 @@ export interface Theme {
    * It should use the prop openDrawer and toggleOpenDrawer to update the drawer state.
    * It will be place in a container of the width `drawerWidth`
    */
-  permanentHeader?: React.ElementType<any>
+  permanentHeader?: React.ComponentType<PermanentHeaderThemeProps>
   /**
    * The breakpoint where the drawer becom absolute above the main content when opened
    * @default "md"

--- a/packages/themes/src/ThemeContextProvider/ThemeContextProvider.tsx
+++ b/packages/themes/src/ThemeContextProvider/ThemeContextProvider.tsx
@@ -17,7 +17,12 @@ declare module '@mui/styles/defaultTheme' {
   interface DefaultTheme extends Theme {}
 }
 
-export interface ThemeContextProps {
+export interface PermanentHeaderThemeProps {
+  toggleOpenDrawer: () => void
+  openDrawer: boolean
+}
+
+export interface ThemeContextProps extends PermanentHeaderThemeProps {
   theme: Theme
   changeTheme: (theme: Partial<Theme>) => void
   openDrawer: boolean


### PR DESCRIPTION
Corrects the typo in the variable name from PerManentHeader to PermanentHeader for consistency and readability.

fix(theme): update permanentHeader type to use PermanentHeaderThemeProps

Changes the type of permanentHeader in the Theme interface to use React.ComponentType<PermanentHeaderThemeProps> for better type safety and clarity. Adds PermanentHeaderThemeProps interface to define the expected props for the PermanentHeader component.