### PR TITLE
refactor(theme): rename PermanentHeaderThemeProps to ThemePermanentHeaderProps for consistency

### DIFF
--- a/packages/themes/src/ThemeContextProvider/Theme.tsx
+++ b/packages/themes/src/ThemeContextProvider/Theme.tsx
@@ -6,7 +6,7 @@ import {
 } from '@mui/material'
 import tinycolor from 'tinycolor2'
 import { mergeDeepRight } from 'ramda'
-import { PermanentHeaderThemeProps } from './ThemeContextProvider'
+import { ThemePermanentHeaderProps } from './ThemeContextProvider'
 
 export interface Theme {
   name?: string
@@ -20,7 +20,7 @@ export interface Theme {
    * It should use the prop openDrawer and toggleOpenDrawer to update the drawer state.
    * It will be place in a container of the width `drawerWidth`
    */
-  permanentHeader?: React.ComponentType<PermanentHeaderThemeProps>
+  permanentHeader?: React.ComponentType<ThemePermanentHeaderProps>
   /**
    * The breakpoint where the drawer becom absolute above the main content when opened
    * @default "md"

--- a/packages/themes/src/ThemeContextProvider/ThemeContextProvider.tsx
+++ b/packages/themes/src/ThemeContextProvider/ThemeContextProvider.tsx
@@ -17,12 +17,12 @@ declare module '@mui/styles/defaultTheme' {
   interface DefaultTheme extends Theme {}
 }
 
-export interface PermanentHeaderThemeProps {
+export interface ThemePermanentHeaderProps {
   toggleOpenDrawer: () => void
   openDrawer: boolean
 }
 
-export interface ThemeContextProps extends PermanentHeaderThemeProps {
+export interface ThemeContextProps extends ThemePermanentHeaderProps {
   theme: Theme
   changeTheme: (theme: Partial<Theme>) => void
   openDrawer: boolean

--- a/packages/themes/src/index.ts
+++ b/packages/themes/src/index.ts
@@ -1,4 +1,5 @@
 export {
+  ThemePermanentHeaderProps,
   Theme,
   ThemeColors,
   ThemeContextProvider,


### PR DESCRIPTION
Renaming `PermanentHeaderThemeProps` to `ThemePermanentHeaderProps` aligns with the naming conventions used throughout the codebase, improving readability and maintainability. This change ensures that all theme-related properties follow a consistent naming pattern.