### PR TITLE
chore(AutoComplete.tsx): remove unused onInputChange prop from AutoCompleteBase component

### DIFF
--- a/packages/forms/src/AutoComplete/AutoComplete.tsx
+++ b/packages/forms/src/AutoComplete/AutoComplete.tsx
@@ -165,7 +165,6 @@ const AutoCompleteBase = function <T>(
     returnFullObject = false,
     chipProps,
     helperText,
-    onInputChange,
     ...other
   } = props
   console.log('AutoCompleteBase', props)


### PR DESCRIPTION
Cleaning up the component by removing the unused onInputChange prop helps to reduce clutter and improve code readability. This change also prevents potential confusion for future developers regarding the purpose of the prop.