### PR TITLE
fix(AutoComplete.tsx): update cleanedValues logic to return null instead of undefined when values are empty or value is undefined

### DIFF
--- a/packages/forms/src/AutoComplete/AutoComplete.tsx
+++ b/packages/forms/src/AutoComplete/AutoComplete.tsx
@@ -280,7 +280,7 @@ const AutoCompleteBase = function <T>(
     []
   )
   const cleanedValues = useMemo(
-    () => (values?.length === 0 ? undefined : values),
+    () => (values?.length === 0 || value === undefined ? null : values),
     [values]
   )
 


### PR DESCRIPTION
The logic for cleanedValues is modified to return null when the values array is empty or when the value is undefined. This change ensures that the component handles these cases more gracefully, providing a clearer indication of the absence of values.