### PR TITLE
fix(AutoComplete.tsx): change cleanedValues default from null to defa…

### DIFF
--- a/packages/forms/src/AutoComplete/AutoComplete.tsx
+++ b/packages/forms/src/AutoComplete/AutoComplete.tsx
@@ -26,6 +26,7 @@ const useStyles = makeG2STyles()({
     padding: '0px'
   }
 })
+const defaultEmpty = []
 
 export interface AutoCompleteBasicProps<T> extends BasicProps {
   /**
@@ -280,7 +281,7 @@ const AutoCompleteBase = function <T>(
     []
   )
   const cleanedValues = useMemo(
-    () => (values?.length === 0 || value === undefined ? null : values),
+    () => (values?.length === 0 || value === undefined ? defaultEmpty : values),
     [values]
   )
 


### PR DESCRIPTION
…ultEmpty for better handling of empty values

The cleanedValues now defaults to an empty array instead of null when there are no values or when the value is undefined. This change improves the handling of empty states in the AutoComplete component, ensuring that it consistently returns an array type, which can prevent potential errors in downstream components that expect an array.