### PR TITLE
chore(AutoComplete.tsx): remove console.log statement for cleaner code

### DIFF
--- a/packages/forms/src/AutoComplete/AutoComplete.tsx
+++ b/packages/forms/src/AutoComplete/AutoComplete.tsx
@@ -167,7 +167,6 @@ const AutoCompleteBase = function <T>(
     helperText,
     ...other
   } = props
-  console.log('AutoComplete', props)
   //@ts-ignore
   const hasKey = !!options[0]?.key
 


### PR DESCRIPTION
Removing the console.log statement helps to maintain a cleaner codebase and prevents unnecessary logging in production, which can improve performance and reduce clutter in the console output.