### PR TITLE
chore(AutoComplete.tsx): comment out unused defaultEmpty variable to clean up code

### DIFF
--- a/packages/forms/src/AutoComplete/AutoComplete.tsx
+++ b/packages/forms/src/AutoComplete/AutoComplete.tsx
@@ -125,7 +125,7 @@ export type AutoCompleteProps<T = any> = MergeMuiElementProps<
   Omit<MuiAutocompleteProps<T, undefined, undefined, undefined>, 'renderInput'>,
   AutoCompleteBasicProps<T>
 >
-const defaultEmpty = []
+// const defaultEmpty = []
 const defaultFilterOptions = createFilterOptions()
 export const defaultGetOptionLabel =
   (options: any[], hasKey: boolean) => (option: any) => {


### PR DESCRIPTION
Removing the defaultEmpty variable helps to declutter the codebase by eliminating unused code. This improves readability and maintainability of the AutoComplete component.