### PR TITLE
chore(AutoComplete.tsx): remove console.log statement to clean up code

### DIFF
--- a/packages/forms/src/AutoComplete/AutoComplete.tsx
+++ b/packages/forms/src/AutoComplete/AutoComplete.tsx
@@ -285,7 +285,6 @@ const AutoCompleteBase = function <T>(
         : values,
     [values]
   )
-  console.log(props.id, multiple, value, values, cleanedValues)
   return (
     <MuiAutocomplete<T, boolean, undefined, boolean>
       id={id}


### PR DESCRIPTION
Removing the console.log statement helps to declutter the code and prevents unnecessary logging during runtime, which can improve performance and maintain cleaner output in the console.