### PR TITLE
chore: Add on-tag option to npm publish action

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,6 +21,7 @@ jobs:
       NPM_PKG_NPMJS_TOKEN: ${{ secrets.NPM_PKG_NPMJS_TOKEN}}
     with:
       with-docker-registry-login: false
+      on-tag: 'publish promote'
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@0.23.0


### PR DESCRIPTION
Enhancement: Added the on-tag: 'publish promote' option to the npm publish workflow for more granular control over package publishing.
Impact: Ensures package promotions only execute when appropriate tags are created, improving the reliability of release processes.